### PR TITLE
Bugfix: Fatal error when Session class is not loaded.

### DIFF
--- a/libraries/Profiler.php
+++ b/libraries/Profiler.php
@@ -426,25 +426,28 @@ class CI_Profiler {
 	function _compile_userdata()
 	{
 		$output = array();
-	
-		$compiled_userdata = $this->CI->session->all_userdata();
 		
-		if (count($compiled_userdata))
+		if (FALSE !== $this->CI->load->is_loaded('session'))
 		{		
-			foreach ($compiled_userdata as $key => $val)
-			{
-				if (is_numeric($key))
+			$compiled_userdata = $this->CI->session->all_userdata();
+			
+			if (count($compiled_userdata))
+			{		
+				foreach ($compiled_userdata as $key => $val)
 				{
-					$output[$key] = "'$val'";
-				}
-				
-				if (is_array($val))
-				{
-					$output[$key] = htmlspecialchars(stripslashes(print_r($val, true)));
-				}
-				else
-				{
-					$output[$key] = htmlspecialchars(stripslashes($val));
+					if (is_numeric($key))
+					{
+						$output[$key] = "'$val'";
+					}
+					
+					if (is_array($val))
+					{
+						$output[$key] = htmlspecialchars(stripslashes(print_r($val, true)));
+					}
+					else
+					{
+						$output[$key] = htmlspecialchars(stripslashes($val));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
_compile_userdata(), which is called by the class constructor, leads to a fatal error if the Session library is not loaded.

I've just added a check to test whether the Session library is loaded.
