### PR TITLE
Invalid argument supplied for foreach()

### DIFF
--- a/libraries/Profiler.php
+++ b/libraries/Profiler.php
@@ -233,7 +233,7 @@ class CI_Profiler extends CI_Loader {
 
 		$get = $this->CI->input->get();
 
-		if (count($get) == 0)
+		if (count($get) == 0 || $get === false)
 		{
 			$output = $this->CI->lang->line('profiler_no_get');
 		}


### PR DESCRIPTION
fix for invalid argument supplied for foreach() in libraries/Profiler.php line number: 242 when count($get) return 1 when $get == true
add extra check when $get == false
