### PR TITLE
Fixing Linux Environment Uppercase

### DIFF
--- a/libraries/Profiler.php
+++ b/libraries/Profiler.php
@@ -234,7 +234,7 @@ class CI_Profiler extends CI_Loader {
 		$output = array();
 		
 		// hack to make eloquent not throw error for now
-		$this->CI->load->model('eloquent/assets/action');
+		$this->CI->load->model('Eloquent/Assets/Action');
 		
 		if ( ! class_exists('Illuminate\Database\Capsule\Manager')) {
 			$output = 'Illuminate\Database has not been loaded.';


### PR DESCRIPTION
Codeigniter 3 read first letter of uppercase. If ci-forensic running in
linux environment, erros shows -> Unable to locate the model you have
specified: Action