### PR TITLE
Fixes "Illegal string offset" in PHP 7.1.

### DIFF
--- a/libraries/Profiler.php
+++ b/libraries/Profiler.php
@@ -565,7 +565,7 @@ class CI_Profiler extends CI_Loader {
 	 */
 	public function _compile_view_data()
 	{
-		$output = '';
+		$output = array();
 
 		foreach ($this->_ci_cached_vars as $key => $val)
 		{


### PR DESCRIPTION
I was running this on PHP 7.1. and spotted this minor issue. I hope this is of help!