### PR TITLE
fix for user section: correctly handled objects byt encoding and decoding

### DIFF
--- a/libraries/Profiler.php
+++ b/libraries/Profiler.php
@@ -549,16 +549,19 @@ class CI_Profiler extends CI_Loader {
 				{
 					if (is_numeric($key))
 					{
-						$output[$key] = "'$val'";
+						$output[$key] = print_r($val,true);
 					}
 
 					if (is_array($val) || is_object($val))
 					{
-						$output[$key] = htmlspecialchars(stripslashes(print_r($val, true)));
+						if (is_object($val))
+							$output[$key] = json_decode(json_encode($val), true);
+						else
+							$output[$key] = htmlspecialchars(stripslashes(print_r($val, true)));
 					}
 					else
 					{
-						$output[$key] = htmlspecialchars(stripslashes($val));
+						$output[$key] = htmlspecialchars(stripslashes(print_r($val, true)));
 					}
 				}
 			}


### PR DESCRIPTION
* fixeds https://github.com/lonnieezell/codeigniter-forensics/issues/9 in correct way
* closed https://github.com/lonnieezell/codeigniter-forensics/issues/9 in correct way
* fix https://github.com/lonnieezell/codeigniter-forensics/issues/9 as requested

Please @lonnieezell merged that pull that solved and i finally tested and get property solved!

i'll use `json_decode(json_encode($object), true);` due following reasons:

* since php 5.4 json_encode have JSON_OBJECT_AS_ARRAY, http://php.net/manual/en/json.constants.php but it not was used by me in the pull request due i wants to be available for any version of php supported by any codeigniter 2 or 3, so php 5.2 must be supported.
* also inline casting as (array)$object that seems supported since php 5.2 so will be fully compatible but not so fancy

**NOTE** that this pull has "allow edits from mantainers" so you can edit and added commits directly if need!